### PR TITLE
use build for Speed + parallel build

### DIFF
--- a/Tools/wasm/wasix-configure-wrapper
+++ b/Tools/wasm/wasix-configure-wrapper
@@ -70,7 +70,7 @@ export LD="wasixld"
 
 export CFLAGS="\
   -DOPENSSL_THREADS \
-  -Os -flto"
+  -flto"
 
 WASIXCC_RUN_WASM_OPT=no \
   "$@" \

--- a/Tools/wasm/wasm_build.py
+++ b/Tools/wasm/wasm_build.py
@@ -563,7 +563,7 @@ class BuildProfile:
     @property
     def make_cmd(self) -> List[str]:
         """Generate make command"""
-        cmd = ["make"]
+        cmd = ["make", "-j8"]
         platform = self.host.platform
         if platform.make_wrapper:
             cmd.insert(0, os.fspath(platform.make_wrapper))


### PR DESCRIPTION
We are suppose to build the Python interpreter with the project default option value (that's `-O3`). The `-Os` option is undesirable.